### PR TITLE
Inject VITE_BUCKET_PUBLIC_URL as build-time argument in Dockerfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,5 +32,5 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/marvticle:${{ github.sha }}
           platforms: linux/amd64
           build-args: |
-            VITE_APP_TITLE=${{ vars.VITE_APP_TITLE }}
+            VITE_APP_URL=${{ vars.VITE_APP_URL }}
             VITE_BUCKET_PUBLIC_URL=${{ vars.VITE_BUCKET_PUBLIC_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,3 +31,6 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/marvticle:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/marvticle:${{ github.sha }}
           platforms: linux/amd64
+          build-args: |
+            VITE_APP_TITLE=${{ vars.VITE_APP_TITLE }}
+            VITE_BUCKET_PUBLIC_URL=${{ vars.VITE_BUCKET_PUBLIC_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ COPY . .
 # Public build-time variables from Dokploy Build Arguments.
 # Runtime-only secrets should stay in Dokploy Environment Variables.
 ARG VITE_APP_URL
+ARG VITE_BUCKET_PUBLIC_URL
 ENV VITE_APP_URL=${VITE_APP_URL}
+ENV VITE_BUCKET_PUBLIC_URL=${VITE_BUCKET_PUBLIC_URL}
 
 # build
 RUN bun run build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker build now accepts additional environment variables (VITE_APP_URL and VITE_BUCKET_PUBLIC_URL) so the built app can be configured with a runtime app URL and a public asset bucket URL. This enables more flexible, environment-specific builds and ensures the public bucket URL is available inside the built image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->