### PR TITLE
Add post form routes and update post handling

### DIFF
--- a/src/hooks/use-new-post.ts
+++ b/src/hooks/use-new-post.ts
@@ -1,0 +1,52 @@
+import { useMutation } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useNavigate } from '@tanstack/react-router'
+import type { QueryClient } from '@tanstack/react-query'
+import type { orpc } from '#/orpc/client'
+import {
+  DEFAULT_POSTS_LIMIT,
+  postsInfiniteQueryOptions,
+} from '#/hooks/use-posts'
+
+interface UseNewPostOptions {
+  queryClient: QueryClient
+  orpc: typeof orpc
+  username: string
+}
+
+export const useNewPost = ({
+  orpc,
+  queryClient,
+  username,
+}: UseNewPostOptions) => {
+  const navigate = useNavigate()
+
+  return useMutation(
+    orpc.posts.create.mutationOptions({
+      onSuccess: (data) => {
+        void queryClient.invalidateQueries({
+          queryKey: postsInfiniteQueryOptions(DEFAULT_POSTS_LIMIT).queryKey,
+        })
+
+        toast.success('Post published', {
+          description: 'Your article is now live on the feed.',
+        })
+
+        void navigate({
+          to: '/$username/$postSlug',
+          params: {
+            username,
+            postSlug: data.slug,
+          },
+          viewTransition: true,
+        })
+      },
+
+      onError: (error) => {
+        toast.error('Failed to publish post', {
+          description: error.message,
+        })
+      },
+    })
+  )
+}

--- a/src/hooks/use-post-detail.ts
+++ b/src/hooks/use-post-detail.ts
@@ -10,6 +10,18 @@ export const postDetailQueryOptions = (username: string, slug: string) =>
     },
   })
 
+export const editablePostDetailQueryOptions = (username: string, slug: string) =>
+  orpc.posts.getEditableByUsernameAndSlug.queryOptions({
+    input: {
+      username,
+      slug,
+    },
+  })
+
 export const usePostDetail = (username: string, slug: string) => {
   return useSuspenseQuery(postDetailQueryOptions(username, slug))
+}
+
+export const useEditablePostDetail = (username: string, slug: string) => {
+  return useSuspenseQuery(editablePostDetailQueryOptions(username, slug))
 }

--- a/src/hooks/use-update-post.ts
+++ b/src/hooks/use-update-post.ts
@@ -1,0 +1,65 @@
+import { useMutation } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useNavigate } from '@tanstack/react-router'
+import type { QueryClient } from '@tanstack/react-query'
+
+import type { orpc } from '#/orpc/client'
+import {
+  editablePostDetailQueryOptions,
+  postDetailQueryOptions,
+} from '#/hooks/use-post-detail'
+import {
+  DEFAULT_POSTS_LIMIT,
+  postsInfiniteQueryOptions,
+} from '#/hooks/use-posts'
+
+interface UseUpdatePostOptions {
+  queryClient: QueryClient
+  orpc: typeof orpc
+  username: string
+}
+
+export const useUpdatePost = ({
+  orpc,
+  queryClient,
+  username,
+}: UseUpdatePostOptions) => {
+  const navigate = useNavigate()
+
+  return useMutation(
+    orpc.posts.update.mutationOptions({
+      onSuccess: (data) => {
+        void queryClient.invalidateQueries({
+          queryKey: editablePostDetailQueryOptions(username, data.slug).queryKey,
+        })
+
+        void queryClient.invalidateQueries({
+          queryKey: postDetailQueryOptions(username, data.slug).queryKey,
+        })
+
+        void queryClient.invalidateQueries({
+          queryKey: postsInfiniteQueryOptions(DEFAULT_POSTS_LIMIT).queryKey,
+        })
+
+        toast.success('Post updated')
+
+        if (data.status === 'PUBLISHED') {
+          void navigate({
+            to: '/$username/$postSlug',
+            params: {
+              username,
+              postSlug: data.slug,
+            },
+            viewTransition: true,
+          })
+        }
+      },
+
+      onError: (error) => {
+        toast.error('Failed to update post', {
+          description: error.message,
+        })
+      },
+    })
+  )
+}

--- a/src/orpc/contracts/posts.contract.ts
+++ b/src/orpc/contracts/posts.contract.ts
@@ -5,6 +5,7 @@ import {
   getOnePostByUsernameAndSlugParamsSchema,
   postSchema,
   postsPageSchema,
+  updatePostInputSchema,
 } from '#/schemas/posts.schema'
 
 const getManyPostsContract = base
@@ -37,6 +38,21 @@ const getOneByUsernameAndSlugContract = base
   .input(getOnePostByUsernameAndSlugParamsSchema)
   .output(postSchema)
 
+const getEditableByUsernameAndSlugContract = base
+  .route({
+    path: '/posts/{username}/{slug}/edit',
+    method: 'GET',
+    summary: 'Get editable post by username and slug',
+    description:
+      'Retrieve a post owned by the authenticated author for editing.',
+    tags: ['Posts'],
+    operationId: 'getEditablePostByUsernameAndSlug',
+    successStatus: 200,
+    successDescription: 'Editable post retrieved successfully',
+  })
+  .input(getOnePostByUsernameAndSlugParamsSchema)
+  .output(postSchema.omit({ author: true }))
+
 const createPostContract = base
   .route({
     path: '/posts',
@@ -51,8 +67,24 @@ const createPostContract = base
   .input(createPostBodySchema)
   .output(postSchema.omit({ author: true }))
 
+const updatePostContract = base
+  .route({
+    path: '/posts/{id}',
+    method: 'PATCH',
+    summary: 'Update a post',
+    description: 'Update an existing post owned by the authenticated author.',
+    tags: ['Posts'],
+    operationId: 'updatePost',
+    successStatus: 200,
+    successDescription: 'Post updated successfully',
+  })
+  .input(updatePostInputSchema)
+  .output(postSchema.omit({ author: true }))
+
 export const postsContract = {
   getMany: getManyPostsContract,
   getOneByUsernameAndSlug: getOneByUsernameAndSlugContract,
+  getEditableByUsernameAndSlug: getEditableByUsernameAndSlugContract,
   create: createPostContract,
+  update: updatePostContract,
 }

--- a/src/orpc/routers/posts.router.ts
+++ b/src/orpc/routers/posts.router.ts
@@ -6,6 +6,13 @@ import { orpcBase } from '#/orpc'
 import { orpcRequireAuthMiddleware } from '#/orpc/middlewares'
 import { postPaginationCursorSchema } from '#/schemas/posts.schema'
 
+type UpdatePostValues = Partial<
+  Pick<
+    typeof postsTable.$inferInsert,
+    'title' | 'coverImage' | 'content' | 'status'
+  >
+>
+
 const generateSlug = (title: string): string => {
   return `${limax(title)}-${nanoid(5)}`
 }
@@ -148,6 +155,53 @@ const getOneByUsernameAndSlugHandler =
     }
   )
 
+const getEditableByUsernameAndSlugHandler = orpcBase
+  .use(orpcRequireAuthMiddleware)
+  .posts.getEditableByUsernameAndSlug.handler(
+    async ({ context, input, errors }) => {
+      const [row] = await context.db
+        .select({
+          ...createdPostSelect,
+          authorId: postsTable.authorId,
+        })
+        .from(postsTable)
+        .innerJoin(userTable, eq(postsTable.authorId, userTable.id))
+        .where(
+          and(
+            eq(userTable.username, input.username),
+            eq(postsTable.slug, input.slug)
+          )
+        )
+        .limit(1)
+
+      if (!row) {
+        throw errors.NOT_FOUND({
+          message: `Post @${input.username}/${input.slug} not found.`,
+        })
+      }
+
+      if (row.authorId !== context.auth.user.id) {
+        throw errors.FORBIDDEN({
+          message: 'You can only edit your own posts.',
+        })
+      }
+
+      return {
+        id: row.id,
+        slug: row.slug,
+        title: row.title,
+        coverImage: row.coverImage,
+        content: row.content,
+        status: row.status,
+        viewsCount: row.viewsCount,
+        likesCount: row.likesCount,
+        commentsCount: row.commentsCount,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      }
+    }
+  )
+
 const createPostHandler = orpcBase
   .use(orpcRequireAuthMiddleware)
   .posts.create.handler(async ({ context, input, errors }) => {
@@ -171,8 +225,66 @@ const createPostHandler = orpcBase
     return post
   })
 
+const updatePostHandler = orpcBase
+  .use(orpcRequireAuthMiddleware)
+  .posts.update.handler(async ({ context, input, errors }) => {
+    const [existingPost] = await context.db
+      .select({
+        authorId: postsTable.authorId,
+      })
+      .from(postsTable)
+      .where(eq(postsTable.id, input.id))
+      .limit(1)
+
+    if (!existingPost) {
+      throw errors.NOT_FOUND({
+        message: 'Post not found.',
+      })
+    }
+
+    if (existingPost.authorId !== context.auth.user.id) {
+      throw errors.FORBIDDEN({
+        message: 'You can only update your own posts.',
+      })
+    }
+
+    const updateValues: UpdatePostValues = {}
+
+    if (input.title !== undefined) {
+      updateValues.title = input.title
+    }
+
+    if (input.coverImage !== undefined) {
+      updateValues.coverImage = input.coverImage || null
+    }
+
+    if (input.content !== undefined) {
+      updateValues.content = input.content
+    }
+
+    if (input.status !== undefined) {
+      updateValues.status = input.status
+    }
+
+    const [post] = await context.db
+      .update(postsTable)
+      .set(updateValues)
+      .where(eq(postsTable.id, input.id))
+      .returning(createdPostSelect)
+
+    if (!post) {
+      throw errors.INTERNAL_SERVER_ERROR({
+        message: 'Failed to update post.',
+      })
+    }
+
+    return post
+  })
+
 export const postsRouter = {
   getMany: getManyPostsHandler,
   getOneByUsernameAndSlug: getOneByUsernameAndSlugHandler,
+  getEditableByUsernameAndSlug: getEditableByUsernameAndSlugHandler,
   create: createPostHandler,
+  update: updatePostHandler,
 }

--- a/src/orpc/routers/posts.router.ts
+++ b/src/orpc/routers/posts.router.ts
@@ -160,14 +160,12 @@ const getEditableByUsernameAndSlugHandler = orpcBase
   .posts.getEditableByUsernameAndSlug.handler(
     async ({ context, input, errors }) => {
       const [row] = await context.db
-        .select({
-          ...createdPostSelect,
-          authorId: postsTable.authorId,
-        })
+        .select(createdPostSelect)
         .from(postsTable)
         .innerJoin(userTable, eq(postsTable.authorId, userTable.id))
         .where(
           and(
+            eq(userTable.id, context.auth.user.id),
             eq(userTable.username, input.username),
             eq(postsTable.slug, input.slug)
           )
@@ -177,12 +175,6 @@ const getEditableByUsernameAndSlugHandler = orpcBase
       if (!row) {
         throw errors.NOT_FOUND({
           message: `Post @${input.username}/${input.slug} not found.`,
-        })
-      }
-
-      if (row.authorId !== context.auth.user.id) {
-        throw errors.FORBIDDEN({
-          message: 'You can only edit your own posts.',
         })
       }
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,20 +9,21 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as NewRouteImport } from './routes/new'
+import { Route as PostFormRouteImport } from './routes/_post-form'
 import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as AppIndexRouteImport } from './routes/_app/index'
+import { Route as PostFormNewRouteImport } from './routes/_post-form/new'
 import { Route as AuthSignUpRouteImport } from './routes/_auth/sign-up'
 import { Route as AuthSignInRouteImport } from './routes/_auth/sign-in'
 import { Route as ApiS3CoverImageRouteImport } from './routes/api/s3.cover-image'
 import { Route as ApiOrpcSplatRouteImport } from './routes/api/orpc.$'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth.$'
 import { Route as AppUsernamePostSlugRouteImport } from './routes/_app/$username/$postSlug'
+import { Route as PostFormUsernamePostSlugEditRouteImport } from './routes/_post-form/$username.$postSlug.edit'
 
-const NewRoute = NewRouteImport.update({
-  id: '/new',
-  path: '/new',
+const PostFormRoute = PostFormRouteImport.update({
+  id: '/_post-form',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthRoute = AuthRouteImport.update({
@@ -37,6 +38,11 @@ const AppIndexRoute = AppIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AppRoute,
+} as any)
+const PostFormNewRoute = PostFormNewRouteImport.update({
+  id: '/new',
+  path: '/new',
+  getParentRoute: () => PostFormRoute,
 } as any)
 const AuthSignUpRoute = AuthSignUpRouteImport.update({
   id: '/sign-up',
@@ -68,79 +74,93 @@ const AppUsernamePostSlugRoute = AppUsernamePostSlugRouteImport.update({
   path: '/$username/$postSlug',
   getParentRoute: () => AppRoute,
 } as any)
+const PostFormUsernamePostSlugEditRoute =
+  PostFormUsernamePostSlugEditRouteImport.update({
+    id: '/$username/$postSlug/edit',
+    path: '/$username/$postSlug/edit',
+    getParentRoute: () => PostFormRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
-  '/new': typeof NewRoute
   '/sign-in': typeof AuthSignInRoute
   '/sign-up': typeof AuthSignUpRoute
+  '/new': typeof PostFormNewRoute
   '/$username/$postSlug': typeof AppUsernamePostSlugRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/api/s3/cover-image': typeof ApiS3CoverImageRoute
+  '/$username/$postSlug/edit': typeof PostFormUsernamePostSlugEditRoute
 }
 export interface FileRoutesByTo {
   '/': typeof AppIndexRoute
-  '/new': typeof NewRoute
   '/sign-in': typeof AuthSignInRoute
   '/sign-up': typeof AuthSignUpRoute
+  '/new': typeof PostFormNewRoute
   '/$username/$postSlug': typeof AppUsernamePostSlugRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/api/s3/cover-image': typeof ApiS3CoverImageRoute
+  '/$username/$postSlug/edit': typeof PostFormUsernamePostSlugEditRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_app': typeof AppRouteWithChildren
   '/_auth': typeof AuthRouteWithChildren
-  '/new': typeof NewRoute
+  '/_post-form': typeof PostFormRouteWithChildren
   '/_auth/sign-in': typeof AuthSignInRoute
   '/_auth/sign-up': typeof AuthSignUpRoute
+  '/_post-form/new': typeof PostFormNewRoute
   '/_app/': typeof AppIndexRoute
   '/_app/$username/$postSlug': typeof AppUsernamePostSlugRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/api/s3/cover-image': typeof ApiS3CoverImageRoute
+  '/_post-form/$username/$postSlug/edit': typeof PostFormUsernamePostSlugEditRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/new'
     | '/sign-in'
     | '/sign-up'
+    | '/new'
     | '/$username/$postSlug'
     | '/api/auth/$'
     | '/api/orpc/$'
     | '/api/s3/cover-image'
+    | '/$username/$postSlug/edit'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
-    | '/new'
     | '/sign-in'
     | '/sign-up'
+    | '/new'
     | '/$username/$postSlug'
     | '/api/auth/$'
     | '/api/orpc/$'
     | '/api/s3/cover-image'
+    | '/$username/$postSlug/edit'
   id:
     | '__root__'
     | '/_app'
     | '/_auth'
-    | '/new'
+    | '/_post-form'
     | '/_auth/sign-in'
     | '/_auth/sign-up'
+    | '/_post-form/new'
     | '/_app/'
     | '/_app/$username/$postSlug'
     | '/api/auth/$'
     | '/api/orpc/$'
     | '/api/s3/cover-image'
+    | '/_post-form/$username/$postSlug/edit'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   AppRoute: typeof AppRouteWithChildren
   AuthRoute: typeof AuthRouteWithChildren
-  NewRoute: typeof NewRoute
+  PostFormRoute: typeof PostFormRouteWithChildren
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiOrpcSplatRoute: typeof ApiOrpcSplatRoute
   ApiS3CoverImageRoute: typeof ApiS3CoverImageRoute
@@ -148,11 +168,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/new': {
-      id: '/new'
-      path: '/new'
-      fullPath: '/new'
-      preLoaderRoute: typeof NewRouteImport
+    '/_post-form': {
+      id: '/_post-form'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof PostFormRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_auth': {
@@ -175,6 +195,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof AppIndexRouteImport
       parentRoute: typeof AppRoute
+    }
+    '/_post-form/new': {
+      id: '/_post-form/new'
+      path: '/new'
+      fullPath: '/new'
+      preLoaderRoute: typeof PostFormNewRouteImport
+      parentRoute: typeof PostFormRoute
     }
     '/_auth/sign-up': {
       id: '/_auth/sign-up'
@@ -218,6 +245,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppUsernamePostSlugRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_post-form/$username/$postSlug/edit': {
+      id: '/_post-form/$username/$postSlug/edit'
+      path: '/$username/$postSlug/edit'
+      fullPath: '/$username/$postSlug/edit'
+      preLoaderRoute: typeof PostFormUsernamePostSlugEditRouteImport
+      parentRoute: typeof PostFormRoute
+    }
   }
 }
 
@@ -245,10 +279,24 @@ const AuthRouteChildren: AuthRouteChildren = {
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
 
+interface PostFormRouteChildren {
+  PostFormNewRoute: typeof PostFormNewRoute
+  PostFormUsernamePostSlugEditRoute: typeof PostFormUsernamePostSlugEditRoute
+}
+
+const PostFormRouteChildren: PostFormRouteChildren = {
+  PostFormNewRoute: PostFormNewRoute,
+  PostFormUsernamePostSlugEditRoute: PostFormUsernamePostSlugEditRoute,
+}
+
+const PostFormRouteWithChildren = PostFormRoute._addFileChildren(
+  PostFormRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   AppRoute: AppRouteWithChildren,
   AuthRoute: AuthRouteWithChildren,
-  NewRoute: NewRoute,
+  PostFormRoute: PostFormRouteWithChildren,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiOrpcSplatRoute: ApiOrpcSplatRoute,
   ApiS3CoverImageRoute: ApiS3CoverImageRoute,

--- a/src/routes/_post-form.tsx
+++ b/src/routes/_post-form.tsx
@@ -1,0 +1,52 @@
+import { Link, Outlet, createFileRoute, redirect } from '@tanstack/react-router'
+import { AppWindowIcon, PencilIcon } from 'lucide-react'
+
+import { Tabs, TabsList, TabsTrigger } from '#/components/ui/tabs'
+
+export const Route = createFileRoute('/_post-form')({
+  beforeLoad: ({ context, location }) => {
+    const { auth } = context
+
+    if (!auth) {
+      throw redirect({
+        to: '/sign-in',
+        search: {
+          redirect: location.pathname,
+        },
+      })
+    }
+
+    return { auth }
+  },
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <Tabs
+      defaultValue="edit"
+      className="flex min-h-svh items-center justify-center"
+    >
+      <header className="fixed top-0 right-0 left-0 z-50 h-14 border-b bg-background/85 backdrop-blur-sm supports-backdrop-filter:bg-background/65">
+        <div className="container mx-auto flex h-full w-full max-w-348 items-center justify-between px-4 md:px-6">
+          <Link to="/" viewTransition>
+            <span className="text-xl font-bold tracking-tighter">
+              Marvticle
+            </span>
+          </Link>
+
+          <TabsList className="gap-2 bg-transparent">
+            <TabsTrigger value="edit">
+              <PencilIcon /> Edit
+            </TabsTrigger>
+            <TabsTrigger value="preview">
+              <AppWindowIcon /> Preview
+            </TabsTrigger>
+          </TabsList>
+        </div>
+      </header>
+
+      <Outlet />
+    </Tabs>
+  )
+}

--- a/src/routes/_post-form/$username.$postSlug.edit.tsx
+++ b/src/routes/_post-form/$username.$postSlug.edit.tsx
@@ -1,140 +1,84 @@
-import {
-  Link,
-  createFileRoute,
-  redirect,
-  useNavigate,
-} from '@tanstack/react-router'
-
-import { AppWindowIcon, PencilIcon } from '@phosphor-icons/react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link, createFileRoute } from '@tanstack/react-router'
 import { useForm } from '@tanstack/react-form-start'
-import { toast } from 'sonner'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '#/components/ui/tabs'
-import { orpc } from '#/orpc/client'
-import { createPostBodySchema } from '#/schemas/posts.schema'
+
+import type { UpdatePostBodyInput } from '#/schemas/posts.schema'
 import {
-  DEFAULT_POSTS_LIMIT,
-  postsInfiniteQueryOptions,
-} from '#/hooks/use-posts'
-import { Field, FieldError, FieldGroup } from '#/components/ui/field'
-import { Textarea } from '#/components/ui/textarea'
+  editablePostDetailQueryOptions,
+  useEditablePostDetail,
+} from '#/hooks/use-post-detail'
+import { useUpdatePost } from '#/hooks/use-update-post'
+import { updatePostBodySchema } from '#/schemas/posts.schema'
+import { ImageDropzone } from '#/components/image-dropzone'
 import { MarkdownEditor } from '#/components/markdown-editor'
-import { Button } from '#/components/ui/button'
-import { Spinner } from '#/components/ui/spinner'
 import { MarkdownRenderer } from '#/components/markdown-renderer'
 import { AspectRatio } from '#/components/ui/aspect-ratio'
-import { ImageDropzone } from '#/components/image-dropzone'
+import { Button } from '#/components/ui/button'
+import { Field, FieldError, FieldGroup, FieldLabel } from '#/components/ui/field'
+import { Spinner } from '#/components/ui/spinner'
+import { TabsContent } from '#/components/ui/tabs'
+import { Textarea } from '#/components/ui/textarea'
+import { ToggleGroup, ToggleGroupItem } from '#/components/ui/toggle-group'
 import { getStorageUrl } from '#/utils/storage'
 
-export const Route = createFileRoute('/new')({
-  beforeLoad: ({ context, location }) => {
-    const { auth } = context
-    if (!auth) {
-      throw redirect({
-        to: '/sign-in',
-        search: {
-          redirect: location.pathname,
-        },
-      })
-    }
+const postStatusOptions = ['PUBLISHED', 'DRAFT', 'ARCHIVED'] as const
 
-    return { auth }
+type PostStatus = (typeof postStatusOptions)[number]
+
+const isPostStatus = (value: string): value is PostStatus => {
+  return postStatusOptions.some((status) => status === value)
+}
+
+export const Route = createFileRoute('/_post-form/$username/$postSlug/edit')({
+  loader: async ({ context: { queryClient }, params }) => {
+    await queryClient.ensureQueryData(
+      editablePostDetailQueryOptions(params.username, params.postSlug)
+    )
   },
-  head: () => ({
-    meta: [
-      {
-        title: 'Create post | marvticle',
-      },
-    ],
-  }),
   component: RouteComponent,
 })
 
 function RouteComponent() {
-  const navigate = useNavigate()
-  const queryClient = useQueryClient()
-  const { auth } = Route.useRouteContext()
-  const username = auth.user.username
+  const params = Route.useParams()
+  const { queryClient, orpc } = Route.useRouteContext()
 
-  const createPostMutation = useMutation(orpc.posts.create.mutationOptions())
+  const { data: post } = useEditablePostDetail(
+    params.username,
+    params.postSlug
+  )
+
+  const updatePostMutation = useUpdatePost({
+    queryClient,
+    orpc,
+    username: params.username,
+  })
+
+  const defaultValues: UpdatePostBodyInput = {
+    title: post.title,
+    coverImage: post.coverImage ?? '',
+    content: post.content,
+    status: post.status,
+  }
 
   const form = useForm({
-    defaultValues: {
-      title: '',
-      coverImage: '',
-      content: '',
-      status: 'PUBLISHED',
-    },
+    defaultValues,
     validators: {
-      onChange: createPostBodySchema,
-      onSubmit: createPostBodySchema,
+      onChange: updatePostBodySchema,
+      onSubmit: updatePostBodySchema,
     },
     onSubmit: async ({ value }) => {
-      try {
-        const post = await createPostMutation.mutateAsync({
-          title: value.title,
-          coverImage: value.coverImage,
-          content: value.content,
-          status: 'PUBLISHED',
-        })
-
-        await queryClient.invalidateQueries({
-          queryKey: postsInfiniteQueryOptions(DEFAULT_POSTS_LIMIT).queryKey,
-        })
-
-        toast.success('Post published', {
-          description: 'Your article is now live on the feed.',
-        })
-
-        await navigate({
-          to: '/$username/$postSlug',
-          params: {
-            username,
-            postSlug: post.slug,
-          },
-          viewTransition: true,
-        })
-      } catch (error) {
-        const description =
-          error instanceof Error
-            ? error.message
-            : 'Something went wrong. Please try again.'
-
-        toast.error('Failed to publish post', {
-          description,
-        })
-      }
+      await updatePostMutation.mutateAsync({
+        id: post.id,
+        ...value,
+      })
     },
   })
 
   return (
-    <Tabs
-      defaultValue="edit"
-      className="flex min-h-svh items-center justify-center"
-    >
-      <header className="fixed top-0 right-0 left-0 z-50 h-14 border-b bg-background/85 backdrop-blur-sm supports-backdrop-filter:bg-background/65">
-        <div className="container mx-auto flex h-full w-full max-w-348 items-center justify-between px-4 md:px-6">
-          <Link to="/" viewTransition>
-            <span className="text-xl font-bold tracking-tighter">
-              Marvticle
-            </span>
-          </Link>
-
-          <TabsList className="gap-2 bg-transparent">
-            <TabsTrigger value="edit">
-              <PencilIcon /> Edit
-            </TabsTrigger>
-            <TabsTrigger value="preview">
-              <AppWindowIcon /> Preview
-            </TabsTrigger>
-          </TabsList>
-        </div>
-      </header>
-
+    <>
       <main className="container mx-auto h-[calc(100vh-8rem)] w-full max-w-4xl overflow-y-auto bg-card px-12 py-8">
         <TabsContent value="edit">
           <form
-            id="create-post-form"
+            id="update-post-form"
             className="space-y-6"
             onSubmit={(e) => {
               e.preventDefault()
@@ -152,7 +96,7 @@ function RouteComponent() {
                   return (
                     <Field data-invalid={isInvalid}>
                       <ImageDropzone
-                        value={field.state.value}
+                        value={field.state.value ?? undefined}
                         onChange={field.handleChange}
                         aria-invalid={isInvalid}
                       />
@@ -242,7 +186,7 @@ function RouteComponent() {
                     >
                       <img
                         src={getStorageUrl(coverImage)}
-                        alt={title}
+                        alt={title ?? ''}
                         className="h-full w-full object-cover"
                       />
                     </AspectRatio>
@@ -269,16 +213,53 @@ function RouteComponent() {
 
       <footer className="fixed right-0 bottom-0 left-0 z-50 h-14">
         <div className="container mx-auto flex h-full w-full max-w-4xl items-center justify-start gap-3">
+          <form.Field
+            name="status"
+            children={(field) => {
+              const isInvalid =
+                field.state.meta.isTouched && !field.state.meta.isValid
+
+              return (
+                <Field
+                  data-invalid={isInvalid}
+                  orientation="horizontal"
+                  className="w-auto items-center"
+                >
+                  <FieldLabel>Status</FieldLabel>
+                  <ToggleGroup
+                    type="single"
+                    value={field.state.value}
+                    onValueChange={(value) => {
+                      if (isPostStatus(value)) {
+                        field.handleChange(value)
+                      }
+                    }}
+                    size="sm"
+                    variant="outline"
+                    aria-invalid={isInvalid}
+                  >
+                    {postStatusOptions.map((status) => (
+                      <ToggleGroupItem key={status} value={status}>
+                        {status}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                </Field>
+              )
+            }}
+          />
+
           <form.Subscribe
             selector={(state) => [state.canSubmit, state.isSubmitting]}
             children={([canSubmit, isSubmitting]) => {
               const canSubmitNow = canSubmit ?? false
               const formIsSubmitting = isSubmitting ?? false
-              const isPending = formIsSubmitting || createPostMutation.isPending
+              const isPending = formIsSubmitting || updatePostMutation.isPending
 
               return (
                 <Button
-                  form="create-post-form"
+                  form="update-post-form"
                   type="submit"
                   size="lg"
                   disabled={!canSubmitNow || isPending}
@@ -286,10 +267,10 @@ function RouteComponent() {
                   {isPending ? (
                     <>
                       <Spinner />
-                      Publishing...
+                      Updating...
                     </>
                   ) : (
-                    'Publish post'
+                    'Update post'
                   )}
                 </Button>
               )
@@ -303,6 +284,6 @@ function RouteComponent() {
           </Button>
         </div>
       </footer>
-    </Tabs>
+    </>
   )
 }

--- a/src/routes/_post-form/new.tsx
+++ b/src/routes/_post-form/new.tsx
@@ -1,0 +1,232 @@
+import { Link, createFileRoute } from '@tanstack/react-router'
+import { useForm } from '@tanstack/react-form-start'
+
+import type { CreatePostBodyInput } from '#/schemas/posts.schema'
+import { ImageDropzone } from '#/components/image-dropzone'
+import { MarkdownEditor } from '#/components/markdown-editor'
+import { MarkdownRenderer } from '#/components/markdown-renderer'
+import { AspectRatio } from '#/components/ui/aspect-ratio'
+import { Button } from '#/components/ui/button'
+import { Field, FieldError, FieldGroup } from '#/components/ui/field'
+import { Spinner } from '#/components/ui/spinner'
+import { TabsContent } from '#/components/ui/tabs'
+import { Textarea } from '#/components/ui/textarea'
+import { useNewPost } from '#/hooks/use-new-post'
+import { createPostBodySchema } from '#/schemas/posts.schema'
+import { getStorageUrl } from '#/utils/storage'
+
+export const Route = createFileRoute('/_post-form/new')({
+  head: () => ({
+    meta: [
+      {
+        title: 'Create post | marvticle',
+      },
+    ],
+  }),
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const { auth, queryClient, orpc } = Route.useRouteContext()
+
+  const createPostMutation = useNewPost({
+    queryClient,
+    orpc,
+    username: auth.user.username,
+  })
+
+  const defaultValues: CreatePostBodyInput = {
+    title: '',
+    coverImage: '',
+    content: '',
+    status: 'PUBLISHED',
+  }
+
+  const form = useForm({
+    defaultValues,
+    validators: {
+      onChange: createPostBodySchema,
+      onSubmit: createPostBodySchema,
+    },
+    onSubmit: async ({ value }) => {
+      await createPostMutation.mutateAsync(value)
+    },
+  })
+
+  return (
+    <>
+      <main className="container mx-auto h-[calc(100vh-8rem)] w-full max-w-4xl overflow-y-auto bg-card px-12 py-8">
+        <TabsContent value="edit">
+          <form
+            id="create-post-form"
+            className="space-y-6"
+            onSubmit={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              void form.handleSubmit()
+            }}
+          >
+            <FieldGroup>
+              <form.Field
+                name="coverImage"
+                children={(field) => {
+                  const isInvalid =
+                    field.state.meta.isTouched && !field.state.meta.isValid
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <ImageDropzone
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        aria-invalid={isInvalid}
+                      />
+                      {isInvalid && (
+                        <FieldError errors={field.state.meta.errors} />
+                      )}
+                    </Field>
+                  )
+                }}
+              />
+
+              <form.Field
+                name="title"
+                children={(field) => {
+                  const isInvalid =
+                    field.state.meta.isTouched && !field.state.meta.isValid
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <Textarea
+                        id={field.name}
+                        name={field.name}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                            e.preventDefault()
+                          }
+                        }}
+                        aria-invalid={isInvalid}
+                        placeholder="New post title here..."
+                        autoComplete="off"
+                        maxLength={180}
+                        className="resize-none border-none bg-transparent! px-0 text-4xl! font-semibold tracking-tight shadow-none ring-0!"
+                      />
+                      {isInvalid && (
+                        <FieldError errors={field.state.meta.errors} />
+                      )}
+                    </Field>
+                  )
+                }}
+              />
+
+              <form.Field
+                name="content"
+                children={(field) => {
+                  const isInvalid =
+                    field.state.meta.isTouched && !field.state.meta.isValid
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <MarkdownEditor
+                        id={field.name}
+                        name={field.name}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        aria-invalid={isInvalid}
+                        placeholder="Write your content here..."
+                      />
+                      {isInvalid && (
+                        <FieldError errors={field.state.meta.errors} />
+                      )}
+                    </Field>
+                  )
+                }}
+              />
+            </FieldGroup>
+          </form>
+        </TabsContent>
+
+        <TabsContent value="preview">
+          <form.Subscribe
+            selector={(state) => [
+              state.values.coverImage,
+              state.values.title,
+              state.values.content,
+            ]}
+            children={([coverImage, title, content]) => {
+              return (
+                <div className="space-y-6">
+                  {coverImage && (
+                    <AspectRatio
+                      ratio={2.38 / 1}
+                      className="overflow-hidden border"
+                    >
+                      <img
+                        src={getStorageUrl(coverImage)}
+                        alt={title}
+                        className="h-full w-full object-cover"
+                      />
+                    </AspectRatio>
+                  )}
+
+                  {title && (
+                    <h1 className="text-3xl leading-tight font-bold tracking-tight">
+                      {title}
+                    </h1>
+                  )}
+
+                  {content && (
+                    <MarkdownRenderer
+                      content={content}
+                      className="max-w-none"
+                    />
+                  )}
+                </div>
+              )
+            }}
+          />
+        </TabsContent>
+      </main>
+
+      <footer className="fixed right-0 bottom-0 left-0 z-50 h-14">
+        <div className="container mx-auto flex h-full w-full max-w-4xl items-center justify-start gap-3">
+          <form.Subscribe
+            selector={(state) => [state.canSubmit, state.isSubmitting]}
+            children={([canSubmit, isSubmitting]) => {
+              const canSubmitNow = canSubmit ?? false
+              const formIsSubmitting = isSubmitting ?? false
+              const isPending = formIsSubmitting || createPostMutation.isPending
+
+              return (
+                <Button
+                  form="create-post-form"
+                  type="submit"
+                  size="lg"
+                  disabled={!canSubmitNow || isPending}
+                >
+                  {isPending ? (
+                    <>
+                      <Spinner />
+                      Publishing...
+                    </>
+                  ) : (
+                    'Publish post'
+                  )}
+                </Button>
+              )
+            }}
+          />
+
+          <Button asChild type="button" variant="outline" size="lg">
+            <Link to="/" viewTransition>
+              Cancel
+            </Link>
+          </Button>
+        </div>
+      </footer>
+    </>
+  )
+}

--- a/src/schemas/posts.schema.ts
+++ b/src/schemas/posts.schema.ts
@@ -79,22 +79,22 @@ const updatePostBodyFieldsSchema = createUpdateSchema(postsTable)
   })
 
 const hasPostUpdateField = (
-  value: Partial<
-    Record<'title' | 'coverImage' | 'content' | 'status', unknown>
-  >
+  value: Partial<Record<'title' | 'coverImage' | 'content' | 'status', unknown>>
 ) => {
   return (
-    'title' in value ||
-    'coverImage' in value ||
-    'content' in value ||
-    'status' in value
+    value.title !== undefined ||
+    value.coverImage !== undefined ||
+    value.content !== undefined ||
+    value.status !== undefined
   )
 }
 
-export const updatePostBodySchema = updatePostBodyFieldsSchema
-  .refine(hasPostUpdateField, {
+export const updatePostBodySchema = updatePostBodyFieldsSchema.refine(
+  hasPostUpdateField,
+  {
     error: 'At least one field is required',
-  })
+  }
+)
 
 export const updatePostInputSchema = updatePostBodyFieldsSchema
   .extend({

--- a/src/schemas/posts.schema.ts
+++ b/src/schemas/posts.schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod'
 
 import { authorSchema } from '#/schemas/users.schema'
-import { createInsertSchema, createSelectSchema } from '#/schemas/drizzle-zod'
+import {
+  createInsertSchema,
+  createSelectSchema,
+  createUpdateSchema,
+} from '#/schemas/drizzle-zod'
 import { postsTable } from '#/db/schemas'
 import { isManagedFileKey } from '#/utils/storage'
 
@@ -46,10 +50,63 @@ export const createPostBodySchema = insertPostSchema
       }),
     ]),
     content: z.string().trim().min(1, { error: 'Content is required' }),
-    status: z.literal('PUBLISHED'),
+    status: z.enum(['DRAFT', 'PUBLISHED', 'ARCHIVED']),
+  })
+
+const updatePostBodyFieldsSchema = createUpdateSchema(postsTable)
+  .pick({
+    title: true,
+    coverImage: true,
+    content: true,
+    status: true,
+  })
+  .extend({
+    title: z.string().trim().min(1, { error: 'Title is required' }).optional(),
+    coverImage: z
+      .union([
+        z.literal(''),
+        z.string().refine(isManagedFileKey, {
+          error: 'Cover image key is invalid',
+        }),
+      ])
+      .optional(),
+    content: z
+      .string()
+      .trim()
+      .min(1, { error: 'Content is required' })
+      .optional(),
+    status: z.enum(['DRAFT', 'PUBLISHED', 'ARCHIVED']).optional(),
+  })
+
+const hasPostUpdateField = (
+  value: Partial<
+    Record<'title' | 'coverImage' | 'content' | 'status', unknown>
+  >
+) => {
+  return (
+    'title' in value ||
+    'coverImage' in value ||
+    'content' in value ||
+    'status' in value
+  )
+}
+
+export const updatePostBodySchema = updatePostBodyFieldsSchema
+  .refine(hasPostUpdateField, {
+    error: 'At least one field is required',
+  })
+
+export const updatePostInputSchema = updatePostBodyFieldsSchema
+  .extend({
+    id: z.uuid(),
+  })
+  .refine(hasPostUpdateField, {
+    error: 'At least one field is required',
   })
 
 export type CreatePostBodyInput = z.infer<typeof createPostBodySchema>
+export type UpdatePostBodyInput = z.infer<typeof updatePostBodySchema>
+export type UpdatePostInput = z.infer<typeof updatePostInputSchema>
 
 export const getManyPostsParamsSchema = z.object({
   cursor: z.string().min(1).optional(),


### PR DESCRIPTION
- Refactor /new to /_post-form layout with nested routes
- Add getEditableByUsernameAndSlug contract and handler
- Add updatePost contract and handler
- Add use-new-post and use-update-post hooks
- Add edit post route at ///edit
- Update posts schema with updatePostBodySchema and updatePostInputSchema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full post edit page with form fields (cover image, title, content), preview tab, status selector (Published/Draft/Archived), and update flow.
  * Post creation flow now uses a dedicated creation hook; shows success/error toasts and navigates to the created post.
  * Success/error toasts and navigation applied to post updates as well.

* **Refactor**
  * Post new/edit routes reorganized under a unified post-form route with auth guard for edit flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->