### PR TITLE
fix: copy public/ to Docker release stage for OG font files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN bun run build
 FROM base AS release
 COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=prerelease /usr/src/app/.output ./.output
+COPY --from=prerelease /usr/src/app/public ./public
 COPY --from=prerelease /usr/src/app/package.json .
 
 # run the app


### PR DESCRIPTION
## Problem

Production logs on Dokploy show `ENOENT` errors when generating OG images:

```
ENOENT: no such file or directory, open '/usr/src/app/public/fonts/inter/inter-latin-600-normal.ttf'
ENOENT: no such file or directory, open '/usr/src/app/public/fonts/inter/inter-latin-400-normal.ttf'
```

## Root Cause

The OG image route (`/api/og`) reads Inter font files at runtime using:

```js
path.join(process.cwd(), 'public', 'fonts', font, fileName)
```

But in the Dockerfile's **release stage**, only `.output/`, `node_modules`, and `package.json` were copied — the `public/` folder was **never included** in the final image.

## Fix

Added one line to the Dockerfile release stage:

```dockerfile
COPY --from=prerelease /usr/src/app/public ./public
```

This ensures the `public/fonts/` directory (and any other runtime-read static assets) are available in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to ensure project assets are included in release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->