### PR TITLE
Introduce threshold-based logic for post update timestamps

### DIFF
--- a/src/components/post-feed-card.tsx
+++ b/src/components/post-feed-card.tsx
@@ -13,6 +13,7 @@ import { AspectRatio } from '#/components/ui/aspect-ratio'
 import { Card, CardContent, CardFooter, CardHeader } from '#/components/ui/card'
 import { Separator } from '#/components/ui/separator'
 import { UserAvatar } from '#/components/user-avatar'
+import { shouldShowPostUpdatedAt } from '#/lib/post-timestamps'
 import { getPostReadTime } from '#/lib/posts'
 import { cn } from '#/lib/utils'
 import { getStorageUrl } from '#/utils/storage'
@@ -27,8 +28,7 @@ export const PostFeedCard = (post: Props) => {
   }
   const publishedAt = post.publishedAt ? new Date(post.publishedAt) : null
   const updatedAt = new Date(post.updatedAt)
-  const showUpdatedAt =
-    publishedAt !== null && updatedAt.getTime() > publishedAt.getTime()
+  const showUpdatedAt = shouldShowPostUpdatedAt({ publishedAt, updatedAt })
 
   return (
     <Card className={cn('gap-4 py-0', !post.coverImage && 'pt-4')}>

--- a/src/db/migrations/0001_forward_profile_and_feed.sql
+++ b/src/db/migrations/0001_forward_profile_and_feed.sql
@@ -1,11 +1,15 @@
-ALTER TABLE "user" ADD COLUMN "banner" text;--> statement-breakpoint
-ALTER TABLE "user" ADD COLUMN "bio" text;--> statement-breakpoint
-ALTER TABLE "user" ADD COLUMN "pronouns" text;--> statement-breakpoint
-ALTER TABLE "user" ADD COLUMN "location" text;--> statement-breakpoint
-ALTER TABLE "user" ADD COLUMN "education" text;--> statement-breakpoint
-ALTER TABLE "user" ADD COLUMN "work" text;--> statement-breakpoint
-ALTER TABLE "user" ADD COLUMN "verified" boolean DEFAULT false NOT NULL;--> statement-breakpoint
-ALTER TABLE "posts" ADD COLUMN "published_at" timestamp;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "banner" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "bio" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "pronouns" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "location" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "education" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "work" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "verified" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "posts" ADD COLUMN IF NOT EXISTS "published_at" timestamp;--> statement-breakpoint
 UPDATE "posts" SET "published_at" = "created_at" WHERE "status" = 'PUBLISHED' AND "published_at" IS NULL;--> statement-breakpoint
-ALTER TABLE "posts" ADD CONSTRAINT "posts_published_at_matches_status" CHECK (("posts"."status" = 'PUBLISHED' AND "posts"."published_at" IS NOT NULL) OR ("posts"."status" <> 'PUBLISHED' AND "posts"."published_at" IS NULL));--> statement-breakpoint
-CREATE INDEX "posts_feed_idx" ON "posts" USING btree ("status","published_at" DESC NULLS LAST,"id" DESC NULLS LAST);
+DO $$ BEGIN
+  ALTER TABLE "posts" ADD CONSTRAINT "posts_published_at_matches_status" CHECK (("posts"."status" = 'PUBLISHED' AND "posts"."published_at" IS NOT NULL) OR ("posts"."status" <> 'PUBLISHED' AND "posts"."published_at" IS NULL));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "posts_feed_idx" ON "posts" USING btree ("status","published_at" DESC NULLS LAST,"id" DESC NULLS LAST);

--- a/src/lib/post-timestamps.test.ts
+++ b/src/lib/post-timestamps.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   getCreatePostTimestampValues,
   getUpdatePostTimestampValues,
+  shouldShowPostUpdatedAt,
 } from '#/lib/post-timestamps'
 
 describe('post timestamp helpers', () => {
@@ -11,6 +12,7 @@ describe('post timestamp helpers', () => {
 
     expect(getCreatePostTimestampValues({ status: 'DRAFT', now })).toEqual({
       publishedAt: null,
+      updatedAt: now,
     })
   })
 
@@ -19,6 +21,7 @@ describe('post timestamp helpers', () => {
 
     expect(getCreatePostTimestampValues({ status: 'PUBLISHED', now })).toEqual({
       publishedAt: now,
+      updatedAt: now,
     })
   })
 
@@ -79,5 +82,12 @@ describe('post timestamp helpers', () => {
         nextStatus: 'PUBLISHED',
       })
     ).toEqual({})
+  })
+
+  it('does not treat direct publish insert timestamp drift as an update', () => {
+    const publishedAt = new Date('2026-04-30T10:00:00.000Z')
+    const updatedAt = new Date('2026-04-30T10:00:00.004Z')
+
+    expect(shouldShowPostUpdatedAt({ publishedAt, updatedAt })).toBe(false)
   })
 })

--- a/src/lib/post-timestamps.ts
+++ b/src/lib/post-timestamps.ts
@@ -15,12 +15,20 @@ export type PostTimestampUpdateValues = {
   publishedAt?: Date | null
 }
 
+type ShouldShowPostUpdatedAtInput = {
+  publishedAt: Date | null
+  updatedAt: Date
+}
+
+const MIN_VISIBLE_UPDATE_DELAY_MS = 1_000
+
 export const getCreatePostTimestampValues = ({
   status,
   now = new Date(),
 }: CreatePostTimestampInput) => {
   return {
     publishedAt: status === 'PUBLISHED' ? now : null,
+    updatedAt: now,
   }
 }
 
@@ -44,4 +52,17 @@ export const getUpdatePostTimestampValues = ({
   return {
     publishedAt: now,
   }
+}
+
+export const shouldShowPostUpdatedAt = ({
+  publishedAt,
+  updatedAt,
+}: ShouldShowPostUpdatedAtInput) => {
+  if (!publishedAt) {
+    return false
+  }
+
+  return (
+    updatedAt.getTime() - publishedAt.getTime() >= MIN_VISIBLE_UPDATE_DELAY_MS
+  )
 }

--- a/src/routes/_app/$username/$postSlug.tsx
+++ b/src/routes/_app/$username/$postSlug.tsx
@@ -23,6 +23,7 @@ import { Skeleton } from '#/components/ui/skeleton'
 import { UserAvatar } from '#/components/user-avatar'
 import { authorProfileQueryOptions } from '#/hooks/use-author-profile'
 import { postDetailQueryOptions } from '#/hooks/use-post-detail'
+import { shouldShowPostUpdatedAt } from '#/lib/post-timestamps'
 import { cn } from '#/lib/utils'
 import { getStorageUrl } from '#/utils/storage'
 import { parseMarkdownToWords } from '#/utils/parse-markdown.ts'
@@ -93,8 +94,7 @@ function RouteComponent() {
   const authorUsername = post.author.username
   const publishedAt = post.publishedAt ? new Date(post.publishedAt) : null
   const updatedAt = new Date(post.updatedAt)
-  const showUpdatedAt =
-    publishedAt !== null && updatedAt.getTime() > publishedAt.getTime()
+  const showUpdatedAt = shouldShowPostUpdatedAt({ publishedAt, updatedAt })
   const unpublishedStatusLabel =
     post.status === 'DRAFT'
       ? 'Draft'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the logic for displaying "Updated" timestamps on posts—they now appear only when posts are updated more than one second after being published, reducing false positives from immediate edits.

* **Chores**
  * Enhanced database schema to support user profile metadata and improved post timestamp tracking with backward-compatible migration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->